### PR TITLE
add: SubPageTitle component

### DIFF
--- a/src/components/SubPageTitle/SubPageTitle.module.css
+++ b/src/components/SubPageTitle/SubPageTitle.module.css
@@ -1,0 +1,12 @@
+.container {
+  display: flex;
+  align-items: center;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.leftbar {
+  width: 5px;
+  height: 35px;
+  margin-right: 20px;
+}

--- a/src/components/SubPageTitle/SubPageTitle.tsx
+++ b/src/components/SubPageTitle/SubPageTitle.tsx
@@ -1,0 +1,19 @@
+'use client'
+import React from 'react'
+import styles from './SubPageTitle.module.css'
+
+type Props = { title: string; barColor?: string }
+
+const SubPageTitle = (props: Props) => {
+  return (
+    <div className={styles.container}>
+      <div
+        className={styles.leftbar}
+        style={{ backgroundColor: props.barColor ?? '#9ed2c6' }}
+      ></div>
+      {props.title}
+    </div>
+  )
+}
+
+export default SubPageTitle


### PR DESCRIPTION
공통 사용 컴포넌트 개발 - 페이지 내부 서브 타이틀

- main 페이지, 주제별 페이지에서 쓰임
- title, barColor를 props로 넘겨주어 타이틀 내용과 왼쪽 바의 색상 변경 가능

![스크린샷 2023-06-20 오전 11 38 42](https://github.com/BookReviewry/bookReviewry_Front/assets/86665569/c4957fca-0df8-41aa-8113-ba468e2bb49f)